### PR TITLE
Messages API

### DIFF
--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -17,7 +17,6 @@ const database = new Sequelize({
 
 database.authenticate()
   .then(async () => {
-    await database.sync({ alter: true });
     console.log('Connection to the database has been established.');
   })
   .catch((error) => {

--- a/src/server/db/models/Message.js
+++ b/src/server/db/models/Message.js
@@ -26,10 +26,10 @@ const Message = database.define(
 */
 Message.belongsTo(Message, { as: 'origin', foreignKey: 'respondingTo' });
 
-Message.belongsTo(User); // UserId
+Message.belongsTo(User); // userId
 User.hasMany(Message);
 
-Message.belongsTo(Topic); // TopicId
+Message.belongsTo(Topic); // topicId
 Topic.hasMany(Message);
 
 module.exports = Message;

--- a/src/server/routes/message.js
+++ b/src/server/routes/message.js
@@ -24,7 +24,7 @@ messageRouter.post('/', async (req, res) => {
         await Message.create(message); // Insert message into Messages table
         res.sendStatus(201);
       } catch (error) {
-        console.error('Failed to POST /api/message');
+        console.error('Failed to POST /api/message', error);
         res.sendStatus(500);
       }
     }
@@ -39,8 +39,19 @@ messageRouter.post('/', async (req, res) => {
     - Set status 200
     - Send back the array of message objects
 */
-messageRouter.get('/:topicId', (req, res) => {
-  res.sendStatus(200);
+messageRouter.get('/:topicId', async (req, res) => {
+  const { topicId } = req.params;
+  try {
+    const messages = await Message.findAll({
+      where: { topicId: +(topicId) },
+      order: [
+        ['createdAt', 'DESC'],
+      ],
+    })
+    res.status(200).send(messages);
+  } catch (error) {
+    console.error('Failed to GET /api/message/:topicId ', error);
+  }
 });
 
 module.exports = messageRouter;

--- a/src/server/routes/message.js
+++ b/src/server/routes/message.js
@@ -1,16 +1,34 @@
 const { Router } = require('express');
 
+const Message = require('../db/models/Message');
+
 const messageRouter = Router();
 
 /*
   POST /api/message
-    - Send fact checked and neutralized message in request body with topic ID: { post: { message, topicId, replyId? } }
+    - Send fact checked and neutralized message in request body with topic ID: { message: { content, topicId, respondingTo? } }
     - Store message in database with topic ID and user ID
       - If the message is replying to a specific message, include the id of the message being replied to
     - Send status 201 for successful POST
 */
-messageRouter.post('/', (req, res) => {
-  res.sendStatus(201);
+messageRouter.post('/', async (req, res) => {
+  if (!req.body.message) { // Check for message object on req.body
+    res.sendStatus(400);
+  } else {
+    const { message } = req.body;
+    if (!message.content || !message.topicId) { // Check for content & topicId on message object
+      res.sendStatus(400);
+    } else {
+      message.userId = req.user.id; // Add userId to message object using req.user.id
+      try {
+        await Message.create(message); // Insert message into Messages table
+        res.sendStatus(201);
+      } catch (error) {
+        console.error('Failed to POST /api/message');
+        res.sendStatus(500);
+      }
+    }
+  }
 });
 
 /*


### PR DESCRIPTION
- Remove DB sync from DB authenticate
  - It was giving me errors on server start
- I wrote these APIs with confidence, but they'll need to be tested when the front-end is built out for the topic discussions
- POST /api/message
  - Must send object in this format: `{ message: { content: STRING, topicId: INTEGER, respondingTo?: INTEGER } }`
- GET /api/message/:topicId
  - Must include the id of the topic being discussed